### PR TITLE
Add default load and unload parameters for loader

### DIFF
--- a/Assets/UGF.Module.AssetBundles.Runtime.Tests/Resources/AssetBundleAssetLoader.asset
+++ b/Assets/UGF.Module.AssetBundles.Runtime.Tests/Resources/AssetBundleAssetLoader.asset
@@ -12,3 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cf69069b73d2437f94d9f6a61a20a3c3, type: 3}
   m_Name: AssetBundleAssetLoader
   m_EditorClassIdentifier: 
+  m_defaultLoadParameters: {}
+  m_defaultUnloadParameters:
+    m_assetBundleUnloadParameters:
+      m_unloadAllLoadedObjects: 1

--- a/Assets/UGF.Module.AssetBundles.Runtime.Tests/Resources/AssetBundleFileLoader.asset
+++ b/Assets/UGF.Module.AssetBundles.Runtime.Tests/Resources/AssetBundleFileLoader.asset
@@ -12,3 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 23f43e15760642d9a2b8436ff3c439ad, type: 3}
   m_Name: AssetBundleFileLoader
   m_EditorClassIdentifier: 
+  m_defaultUnloadParameters:
+    m_unloadAllLoadedObjects: 1

--- a/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleAssetLoadParameters.cs
+++ b/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleAssetLoadParameters.cs
@@ -1,17 +1,21 @@
 ﻿using System;
 using UGF.Module.Assets.Runtime;
+using UnityEngine;
 
 namespace UGF.Module.AssetBundles.Runtime
 {
+    [Serializable]
     public class AssetBundleAssetLoadParameters : IAssetLoadParameters
     {
-        public AssetBundleLoadParameters AssetBundleLoadParameters { get; }
+        [SerializeField] private AssetBundleLoadParameters m_assetBundleLoadParameters;
+
+        public AssetBundleLoadParameters AssetBundleLoadParameters { get { return m_assetBundleLoadParameters; } }
 
         public static AssetBundleAssetLoadParameters Default { get; } = new AssetBundleAssetLoadParameters(AssetBundleLoadParameters.Default);
 
         public AssetBundleAssetLoadParameters(AssetBundleLoadParameters assetBundleLoadParameters)
         {
-            AssetBundleLoadParameters = assetBundleLoadParameters ?? throw new ArgumentNullException(nameof(assetBundleLoadParameters));
+            m_assetBundleLoadParameters = assetBundleLoadParameters ?? throw new ArgumentNullException(nameof(assetBundleLoadParameters));
         }
     }
 }

--- a/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleAssetLoader.cs
+++ b/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleAssetLoader.cs
@@ -10,6 +10,14 @@ namespace UGF.Module.AssetBundles.Runtime
 {
     public class AssetBundleAssetLoader : AssetLoader<AssetBundleAssetInfo, AssetBundleAssetLoadParameters, AssetBundleAssetUnloadParameters>
     {
+        public AssetBundleAssetLoader() : base(AssetBundleAssetLoadParameters.Default, AssetBundleAssetUnloadParameters.Default)
+        {
+        }
+
+        public AssetBundleAssetLoader(AssetBundleAssetLoadParameters defaultLoadParameters, AssetBundleAssetUnloadParameters defaultUnloadParameters) : base(defaultLoadParameters, defaultUnloadParameters)
+        {
+        }
+
         protected override object OnLoad(AssetBundleAssetInfo info, string id, Type type, AssetBundleAssetLoadParameters parameters, IContext context)
         {
             var application = context.Get<IApplication>();

--- a/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleAssetLoaderAsset.cs
+++ b/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleAssetLoaderAsset.cs
@@ -6,9 +6,15 @@ namespace UGF.Module.AssetBundles.Runtime
     [CreateAssetMenu(menuName = "Unity Game Framework/Assets/Asset Bundle Asset Loader", order = 2000)]
     public class AssetBundleAssetLoaderAsset : AssetLoaderAsset
     {
+        [SerializeField] private AssetBundleAssetLoadParameters m_defaultLoadParameters = new AssetBundleAssetLoadParameters(new AssetBundleLoadParameters());
+        [SerializeField] private AssetBundleAssetUnloadParameters m_defaultUnloadParameters = new AssetBundleAssetUnloadParameters(new AssetBundleUnloadParameters());
+
+        public AssetBundleAssetLoadParameters DefaultLoadParameters { get { return m_defaultLoadParameters; } }
+        public AssetBundleAssetUnloadParameters DefaultUnloadParameters { get { return m_defaultUnloadParameters; } }
+
         protected override IAssetLoader OnBuild()
         {
-            return new AssetBundleAssetLoader();
+            return new AssetBundleAssetLoader(m_defaultLoadParameters, m_defaultUnloadParameters);
         }
     }
 }

--- a/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleAssetUnloadParameters.cs
+++ b/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleAssetUnloadParameters.cs
@@ -1,17 +1,21 @@
 ﻿using System;
 using UGF.Module.Assets.Runtime;
+using UnityEngine;
 
 namespace UGF.Module.AssetBundles.Runtime
 {
+    [Serializable]
     public class AssetBundleAssetUnloadParameters : IAssetUnloadParameters
     {
-        public AssetBundleUnloadParameters AssetBundleUnloadParameters { get; }
+        [SerializeField] private AssetBundleUnloadParameters m_assetBundleUnloadParameters;
+
+        public AssetBundleUnloadParameters AssetBundleUnloadParameters { get { return m_assetBundleUnloadParameters; } }
 
         public static AssetBundleAssetUnloadParameters Default { get; } = new AssetBundleAssetUnloadParameters(AssetBundleUnloadParameters.Default);
 
         public AssetBundleAssetUnloadParameters(AssetBundleUnloadParameters assetBundleUnloadParameters)
         {
-            AssetBundleUnloadParameters = assetBundleUnloadParameters ?? throw new ArgumentNullException(nameof(assetBundleUnloadParameters));
+            m_assetBundleUnloadParameters = assetBundleUnloadParameters ?? throw new ArgumentNullException(nameof(assetBundleUnloadParameters));
         }
     }
 }

--- a/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleFileLoader.cs
+++ b/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleFileLoader.cs
@@ -8,6 +8,14 @@ namespace UGF.Module.AssetBundles.Runtime
 {
     public class AssetBundleFileLoader : AssetBundleLoader<AssetBundleFileInfo, AssetBundleLoadParameters, AssetBundleUnloadParameters>
     {
+        public AssetBundleFileLoader() : base(AssetBundleLoadParameters.Default, AssetBundleUnloadParameters.Default)
+        {
+        }
+
+        public AssetBundleFileLoader(AssetBundleLoadParameters defaultLoadParameters, AssetBundleUnloadParameters defaultUnloadParameters) : base(defaultLoadParameters, defaultUnloadParameters)
+        {
+        }
+
         protected override AssetBundle OnLoadAssetBundle(AssetBundleFileInfo info, string id, Type type, AssetBundleLoadParameters parameters, IContext context)
         {
             var application = context.Get<IApplication>();

--- a/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleFileLoaderAsset.cs
+++ b/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleFileLoaderAsset.cs
@@ -6,9 +6,15 @@ namespace UGF.Module.AssetBundles.Runtime
     [CreateAssetMenu(menuName = "Unity Game Framework/Assets/Asset Bundle File Loader", order = 2000)]
     public class AssetBundleFileLoaderAsset : AssetLoaderAsset
     {
+        [SerializeField] private AssetBundleLoadParameters m_defaultLoadParameters = new AssetBundleLoadParameters();
+        [SerializeField] private AssetBundleUnloadParameters m_defaultUnloadParameters = new AssetBundleUnloadParameters();
+
+        public AssetBundleLoadParameters DefaultLoadParameters { get { return m_defaultLoadParameters; } }
+        public AssetBundleUnloadParameters DefaultUnloadParameters { get { return m_defaultUnloadParameters; } }
+
         protected override IAssetLoader OnBuild()
         {
-            return new AssetBundleFileLoader();
+            return new AssetBundleFileLoader(m_defaultLoadParameters, m_defaultUnloadParameters);
         }
     }
 }

--- a/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleLoadParameters.cs
+++ b/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleLoadParameters.cs
@@ -1,7 +1,9 @@
-﻿using UGF.Module.Assets.Runtime;
+﻿using System;
+using UGF.Module.Assets.Runtime;
 
 namespace UGF.Module.AssetBundles.Runtime
 {
+    [Serializable]
     public class AssetBundleLoadParameters : IAssetLoadParameters
     {
         public static AssetBundleLoadParameters Default { get; } = new AssetBundleLoadParameters();

--- a/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleLoader.cs
+++ b/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleLoader.cs
@@ -9,6 +9,14 @@ namespace UGF.Module.AssetBundles.Runtime
 {
     public class AssetBundleLoader : AssetLoader<AssetBundleInfo, AssetBundleLoadParameters, AssetBundleUnloadParameters>
     {
+        public AssetBundleLoader() : base(AssetBundleLoadParameters.Default, AssetBundleUnloadParameters.Default)
+        {
+        }
+
+        public AssetBundleLoader(AssetBundleLoadParameters defaultLoadParameters, AssetBundleUnloadParameters defaultUnloadParameters) : base(defaultLoadParameters, defaultUnloadParameters)
+        {
+        }
+
         protected override object OnLoad(AssetBundleInfo info, string id, Type type, AssetBundleLoadParameters parameters, IContext context)
         {
             var application = context.Get<IApplication>();

--- a/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleLoader`3.cs
+++ b/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleLoader`3.cs
@@ -12,6 +12,10 @@ namespace UGF.Module.AssetBundles.Runtime
         where TLoadParameters : class, IAssetLoadParameters
         where TUnloadParameters : AssetBundleUnloadParameters
     {
+        protected AssetBundleLoader(TLoadParameters defaultLoadParameters, TUnloadParameters defaultUnloadParameters) : base(defaultLoadParameters, defaultUnloadParameters)
+        {
+        }
+
         protected override object OnLoad(TInfo info, string id, Type type, TLoadParameters parameters, IContext context)
         {
             OnLoadDependencies(info, id, type, parameters, context);

--- a/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleUnloadParameters.cs
+++ b/Packages/UGF.Module.AssetBundles/Runtime/AssetBundleUnloadParameters.cs
@@ -1,16 +1,21 @@
-﻿using UGF.Module.Assets.Runtime;
+﻿using System;
+using UGF.Module.Assets.Runtime;
+using UnityEngine;
 
 namespace UGF.Module.AssetBundles.Runtime
 {
+    [Serializable]
     public class AssetBundleUnloadParameters : IAssetUnloadParameters
     {
-        public bool UnloadAllLoadedObjects { get; }
+        [SerializeField] private bool m_unloadAllLoadedObjects;
+
+        public bool UnloadAllLoadedObjects { get { return m_unloadAllLoadedObjects; } }
 
         public static AssetBundleUnloadParameters Default { get; } = new AssetBundleUnloadParameters();
 
         public AssetBundleUnloadParameters(bool unloadAllLoadedObjects = true)
         {
-            UnloadAllLoadedObjects = unloadAllLoadedObjects;
+            m_unloadAllLoadedObjects = unloadAllLoadedObjects;
         }
     }
 }

--- a/Packages/UGF.Module.AssetBundles/package.json
+++ b/Packages/UGF.Module.AssetBundles/package.json
@@ -19,7 +19,7 @@
     "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
   },
   "dependencies": {
-    "com.ugf.module.assets": "4.0.0-preview.2",
+    "com.ugf.module.assets": "4.0.0-preview.3",
     "com.unity.modules.assetbundle": "1.0.0"
   }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "com.ugf.module.assets": "file:../../ugf-module-assets/Packages/UGF.Module.Assets",
     "com.unity.ide.rider": "3.0.7",
     "com.unity.test-framework": "1.1.26"
   },

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "com.ugf.module.assets": "file:../../ugf-module-assets/Packages/UGF.Module.Assets",
     "com.unity.ide.rider": "3.0.7",
     "com.unity.test-framework": "1.1.26"
   },

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "com.ugf.application": {
       "version": "8.0.0-preview.7",
-      "depth": 1,
+      "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.ugf.initialize": "2.6.0",
@@ -14,14 +14,14 @@
     },
     "com.ugf.builder": {
       "version": "2.0.0",
-      "depth": 3,
+      "depth": 4,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.customsettings": {
       "version": "3.4.1",
-      "depth": 4,
+      "depth": 5,
       "source": "registry",
       "dependencies": {
         "com.unity.modules.jsonserialize": "1.0.0",
@@ -31,7 +31,7 @@
     },
     "com.ugf.defines": {
       "version": "2.1.4",
-      "depth": 3,
+      "depth": 4,
       "source": "registry",
       "dependencies": {
         "com.ugf.customsettings": "3.4.1",
@@ -41,7 +41,7 @@
     },
     "com.ugf.description": {
       "version": "2.0.0",
-      "depth": 2,
+      "depth": 3,
       "source": "registry",
       "dependencies": {
         "com.ugf.builder": "2.0.0"
@@ -50,21 +50,21 @@
     },
     "com.ugf.editortools": {
       "version": "1.11.0",
-      "depth": 4,
+      "depth": 5,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.initialize": {
       "version": "2.6.0",
-      "depth": 2,
+      "depth": 3,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.logs": {
       "version": "5.1.4",
-      "depth": 2,
+      "depth": 3,
       "source": "registry",
       "dependencies": {
         "com.ugf.defines": "2.1.4"
@@ -76,21 +76,22 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.ugf.module.assets": "4.0.0-preview.2",
+        "com.ugf.module.assets": "4.0.0-preview.3",
         "com.unity.modules.assetbundle": "1.0.0"
       }
     },
     "com.ugf.module.assets": {
-      "version": "file:../../ugf-module-assets/Packages/UGF.Module.Assets",
-      "depth": 0,
-      "source": "local",
+      "version": "4.0.0-preview.3",
+      "depth": 1,
+      "source": "registry",
       "dependencies": {
         "com.ugf.application": "8.0.0-preview.7"
-      }
+      },
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.runtimetools": {
       "version": "2.0.0",
-      "depth": 2,
+      "depth": 3,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "com.ugf.application": {
       "version": "8.0.0-preview.7",
-      "depth": 2,
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.ugf.initialize": "2.6.0",
@@ -14,14 +14,14 @@
     },
     "com.ugf.builder": {
       "version": "2.0.0",
-      "depth": 4,
+      "depth": 3,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.customsettings": {
       "version": "3.4.1",
-      "depth": 5,
+      "depth": 4,
       "source": "registry",
       "dependencies": {
         "com.unity.modules.jsonserialize": "1.0.0",
@@ -31,7 +31,7 @@
     },
     "com.ugf.defines": {
       "version": "2.1.4",
-      "depth": 4,
+      "depth": 3,
       "source": "registry",
       "dependencies": {
         "com.ugf.customsettings": "3.4.1",
@@ -41,7 +41,7 @@
     },
     "com.ugf.description": {
       "version": "2.0.0",
-      "depth": 3,
+      "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.ugf.builder": "2.0.0"
@@ -50,21 +50,21 @@
     },
     "com.ugf.editortools": {
       "version": "1.11.0",
-      "depth": 5,
+      "depth": 4,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.initialize": {
       "version": "2.6.0",
-      "depth": 3,
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.logs": {
       "version": "5.1.4",
-      "depth": 3,
+      "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.ugf.defines": "2.1.4"
@@ -81,17 +81,16 @@
       }
     },
     "com.ugf.module.assets": {
-      "version": "4.0.0-preview.2",
-      "depth": 1,
-      "source": "registry",
+      "version": "file:../../ugf-module-assets/Packages/UGF.Module.Assets",
+      "depth": 0,
+      "source": "local",
       "dependencies": {
         "com.ugf.application": "8.0.0-preview.7"
-      },
-      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
+      }
     },
     "com.ugf.runtimetools": {
       "version": "2.0.0",
-      "depth": 3,
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"


### PR DESCRIPTION
- Update dependencies: `com.ugf.module.assets` to `4.0.0-preview.3` version.
- Add `AssetBundleLoader`, `AssetBundleAssetLoader` and `AssetBundleFileLoader` constructor with default load and unload parameters.
- Add `AssetBundleAssetLoaderAsset` and `AssetBundleFileLoaderAsset` serializable load and unload parameters.
- Change `AssetBundleLoadParameters`, `AssetBundleUnloadParameters`, `AssetBundleAssetLoadParameters` and `AssetBundleAssetUnloadParameters` parameter classes to be serializable.