### PR TITLE
Remove asset bundle editor info size information

### DIFF
--- a/Packages/UGF.Module.AssetBundles/Editor/AssetBundleEditorInfo.cs
+++ b/Packages/UGF.Module.AssetBundles/Editor/AssetBundleEditorInfo.cs
@@ -10,14 +10,12 @@ namespace UGF.Module.AssetBundles.Editor
         public IReadOnlyList<AssetInfo> Assets { get; }
         public IReadOnlyList<string> Dependencies { get; }
         public bool IsStreamedSceneAssetBundle { get; }
-        public long Size { get; }
 
         public class AssetInfo
         {
             public string Name { get; }
             public Type Type { get; }
             public string Address { get; }
-            public long Size { get; }
 
             public AssetInfo(string name, Type type, string address, long size)
             {
@@ -26,7 +24,6 @@ namespace UGF.Module.AssetBundles.Editor
                 Name = name;
                 Type = type ?? throw new ArgumentNullException(nameof(type));
                 Address = address ?? string.Empty;
-                Size = size;
             }
         }
 
@@ -39,7 +36,6 @@ namespace UGF.Module.AssetBundles.Editor
             Assets = assets ?? throw new ArgumentNullException(nameof(assets));
             Dependencies = dependencies ?? throw new ArgumentNullException(nameof(dependencies));
             IsStreamedSceneAssetBundle = isStreamedSceneAssetBundle;
-            Size = size;
         }
     }
 }

--- a/Packages/UGF.Module.AssetBundles/Editor/AssetBundleEditorInfoAssetInfoDrawer.cs
+++ b/Packages/UGF.Module.AssetBundles/Editor/AssetBundleEditorInfoAssetInfoDrawer.cs
@@ -13,7 +13,6 @@ namespace UGF.Module.AssetBundles.Editor
             SerializedProperty propertyName = serializedProperty.FindPropertyRelative("m_name");
             SerializedProperty propertyType = serializedProperty.FindPropertyRelative("m_type");
             SerializedProperty propertyAddress = serializedProperty.FindPropertyRelative("m_address");
-            SerializedProperty propertySize = serializedProperty.FindPropertyRelative("m_size");
 
             float space = EditorGUIUtility.standardVerticalSpacing;
             float height = EditorGUIUtility.singleLineHeight;
@@ -22,7 +21,6 @@ namespace UGF.Module.AssetBundles.Editor
             var rectName = new Rect(position.x, rectFoldout.yMax + space, position.width, height);
             var rectType = new Rect(position.x, rectName.yMax + space, position.width, height);
             var rectAddress = new Rect(position.x, rectType.yMax + space, position.width, height);
-            var rectSize = new Rect(position.x, rectAddress.yMax + space, position.width, height);
 
             serializedProperty.isExpanded = EditorGUI.Foldout(rectFoldout, serializedProperty.isExpanded, serializedProperty.displayName, true);
 
@@ -33,7 +31,6 @@ namespace UGF.Module.AssetBundles.Editor
                     EditorGUI.PropertyField(rectName, propertyName);
                     EditorGUI.PropertyField(rectType, propertyType);
                     EditorGUI.PropertyField(rectAddress, propertyAddress);
-                    EditorGUI.TextField(rectSize, propertySize.displayName, EditorUtility.FormatBytes(propertySize.longValue));
                 }
             }
         }
@@ -43,7 +40,7 @@ namespace UGF.Module.AssetBundles.Editor
             float space = EditorGUIUtility.standardVerticalSpacing;
             float height = EditorGUIUtility.singleLineHeight;
 
-            return serializedProperty.isExpanded ? height * 5 + space * 4 : height;
+            return serializedProperty.isExpanded ? height * 4 + space * 3 : height;
         }
     }
 }

--- a/Packages/UGF.Module.AssetBundles/Editor/AssetBundleEditorInfoContainer.cs
+++ b/Packages/UGF.Module.AssetBundles/Editor/AssetBundleEditorInfoContainer.cs
@@ -10,7 +10,6 @@ namespace UGF.Module.AssetBundles.Editor
         [SerializeField] private string m_name;
         [SerializeField] private uint m_crc;
         [SerializeField] private bool m_isStreamedSceneAssetBundle;
-        [SerializeField] private long m_size;
         [SerializeField] private List<AssetInfo> m_assets = new List<AssetInfo>();
         [SerializeField] private List<string> m_dependencies = new List<string>();
 
@@ -18,7 +17,6 @@ namespace UGF.Module.AssetBundles.Editor
         public string Name { get { return m_name; } set { m_name = value; } }
         public uint Crc { get { return m_crc; } set { m_crc = value; } }
         public bool IsStreamedSceneAssetBundle { get { return m_isStreamedSceneAssetBundle; } set { m_isStreamedSceneAssetBundle = value; } }
-        public long Size { get { return m_size; } set { m_size = value; } }
         public List<AssetInfo> Assets { get { return m_assets; } }
         public List<string> Dependencies { get { return m_dependencies; } }
 
@@ -28,12 +26,10 @@ namespace UGF.Module.AssetBundles.Editor
             [SerializeField] private string m_name;
             [SerializeField] private string m_type;
             [SerializeField] private string m_address;
-            [SerializeField] private long m_size;
 
             public string Name { get { return m_name; } set { m_name = value; } }
             public string Type { get { return m_type; } set { m_type = value; } }
             public string Address { get { return m_address; } set { m_address = value; } }
-            public long Size { get { return m_size; } set { m_size = value; } }
         }
     }
 }

--- a/Packages/UGF.Module.AssetBundles/Editor/AssetBundleEditorInfoContainerEditor.cs
+++ b/Packages/UGF.Module.AssetBundles/Editor/AssetBundleEditorInfoContainerEditor.cs
@@ -13,7 +13,6 @@ namespace UGF.Module.AssetBundles.Editor
         private SerializedProperty m_propertyName;
         private SerializedProperty m_propertyCrc;
         private SerializedProperty m_propertyIsStreamedSceneAssetBundle;
-        private SerializedProperty m_propertySize;
         private ReorderableListDrawer m_listAssets;
         private ReorderableListDrawer m_listDependencies;
 
@@ -23,7 +22,6 @@ namespace UGF.Module.AssetBundles.Editor
             m_propertyName = serializedObject.FindProperty("m_name");
             m_propertyCrc = serializedObject.FindProperty("m_crc");
             m_propertyIsStreamedSceneAssetBundle = serializedObject.FindProperty("m_isStreamedSceneAssetBundle");
-            m_propertySize = serializedObject.FindProperty("m_size");
             m_listAssets = new ReorderableListDrawer(serializedObject.FindProperty("m_assets"));
             m_listDependencies = new ReorderableListDrawer(serializedObject.FindProperty("m_dependencies"));
 
@@ -61,7 +59,6 @@ namespace UGF.Module.AssetBundles.Editor
                     EditorGUILayout.PropertyField(m_propertyName);
                     EditorGUILayout.PropertyField(m_propertyCrc);
                     EditorGUILayout.PropertyField(m_propertyIsStreamedSceneAssetBundle);
-                    EditorGUILayout.TextField(m_propertySize.displayName, EditorUtility.FormatBytes(m_propertySize.longValue));
 
                     m_listAssets.DrawGUILayout();
                     m_listDependencies.DrawGUILayout();

--- a/Packages/UGF.Module.AssetBundles/Editor/AssetBundleEditorInfoContainerUtility.cs
+++ b/Packages/UGF.Module.AssetBundles/Editor/AssetBundleEditorInfoContainerUtility.cs
@@ -31,7 +31,6 @@ namespace UGF.Module.AssetBundles.Editor
             container.Name = info.Name;
             container.Crc = info.Crc;
             container.IsStreamedSceneAssetBundle = info.IsStreamedSceneAssetBundle;
-            container.Size = info.Size;
             container.Dependencies.AddRange(info.Dependencies);
 
             for (int i = 0; i < info.Assets.Count; i++)
@@ -42,8 +41,7 @@ namespace UGF.Module.AssetBundles.Editor
                 {
                     Name = assetInfo.Name,
                     Type = assetInfo.Type.FullName,
-                    Address = assetInfo.Address,
-                    Size = assetInfo.Size
+                    Address = assetInfo.Address
                 });
             }
 


### PR DESCRIPTION
- Remove size information from `AssetBundleEditorInfo` and `AssetBundleEditorInfoContainer` classes, because it provides wrong information not related to asset bundle size.
- Remove `AssetBundleEditorInfo.Size` and `AssetBundleEditorInfo.AssetInfo.Size` properties.
- Remove `AssetBundleEditorInfoContainer.Size` and `AssetBundleEditorInfoContainer.AssetInfo.Size` properties.